### PR TITLE
Fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The following options can be changed directly from the main menu under `UI Setti
 | -- | -- | -- |
 | Distribution | Used to define which folder to look in for Theme Customization files. | `Batocera`, `RetroBat` | 
 | Aspect Ratio | Enables you to select the correct aspect ratio for your screen.  This will automatically set itself so you should not need to change it but if the theme layout looks odd or spacing looks incorrect you can use this setting to make sure the aspect ratio matches your screen. | `16:9`, `16:10`, `4:3`, `3:2`, `5:3`, `1:1` |
-| Color Scheme | Sets the color scheme that is used for the theme.  There is a set of prebuilt color schemes that you can select and an option to supply your custom color scheme (selected by choosing `custom`).  You can see details on customizations below under [Theme Customziations](#theme-customizations). | `Art Book Next`, `Art Book`, `Steam OS`, `SNES`, `Famicom`, `Black`, `Grayscale`, `Custom` |
-| Font Size | When this is set to custom it allows you to define custom font sizes for the gamelist.  You can see details on customizations below under [Theme Customziations](#theme-customizations). | `Default`, `Custom` |
+| Color Scheme | Sets the color scheme that is used for the theme.  There is a set of prebuilt color schemes that you can select and an option to supply your custom color scheme (selected by choosing `custom`).  You can see details on customizations below under [Theme Customizations](#theme-customizations). | `Art Book Next`, `Art Book`, `Steam OS`, `SNES`, `Famicom`, `Black`, `Grayscale`, `Custom` |
+| Font Size | When this is set to custom it allows you to define custom font sizes for the gamelist.  You can see details on customizations below under [Theme Customizations](#theme-customizations). | `Default`, `Custom` |
 | System View Style | Defines the layout/design used for the System View | `Multi Artwork`, `Centered Artwork (Multiple Logos)`, `Centered Artwork (Single Logo)`, `No Artwork`, `Custom` | 
 | Gamelist View Style | Defines the layout/design used for the Gamelist View | `Metadata On`, `Metadata On (Immersive)`, `Metadata Off`, `Metadata Off (Immersive)` | 
 
@@ -32,7 +32,7 @@ Art Book Next allows customizations to artwork, colors and fonts without the nee
 - This value determines the folder where you will add your customizations
     - Batocera = `userdata/theme-customizations/art-book-next/`
     - Retrobat = `C:\RetroBat\emulationstation\.emulationstation\theme-customizations\art-book-next\`
-- Create the folders that matche your distribution and then move on to the options below... 
+- Create the folders that match your distribution and then move on to the options below... 
 
 ### Background Art
 
@@ -105,6 +105,6 @@ You can modify the font size used to display gamelists
 
 ## **License**
 Creative Commons CC-BY-NC-SA - https://creativecommons.org/licenses/by-nc-sa/2.0/
-You are free to share and adapt this theme as long as you provide attribution back to me (and the above credits) as well share any updates you make under the same licence terms.
+You are free to share and adapt this theme as long as you provide attribution back to me (and the above credits) as well share any updates you make under the same license terms.
 
 Thank you for taking a look at this 😄

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Art Book Next for EmulationStation
-A simple theme for the version of EmulationStation used in [Batocera](https://batocera.org/).  
+A simple theme for the version of EmulationStation used in [Batocera](https://batocera.org/).
 Based on the style of a coffee table book.
 
 This version of the theme works with all distributions that leverage the Batocera fork of EmulationStation.  This includes [Batocera](https://batocera.org/) and [RetroBat](https://www.retrobat.org/)
 
 ## Preview
-| ![system view](https://github.com/anthonycaccese/art-book-next-es/assets/1454947/c0252388-2268-444c-ae3d-07f15b87a98c) | ![menu](https://github.com/anthonycaccese/art-book-next-es/assets/1454947/39653703-f6e8-4940-98fc-66ce1c5af271) | 
+| ![system view](https://github.com/anthonycaccese/art-book-next-es/assets/1454947/c0252388-2268-444c-ae3d-07f15b87a98c) | ![menu](https://github.com/anthonycaccese/art-book-next-es/assets/1454947/39653703-f6e8-4940-98fc-66ce1c5af271) |
 | -- | -- |
 | ![gamelist-view-1](https://github.com/anthonycaccese/art-book-next-es/assets/1454947/e8251f3c-f033-43ed-8b55-f3a93c28131a) | ![gamelist-view-2](https://github.com/anthonycaccese/art-book-next-es/assets/1454947/fadfba3e-54a4-48e2-a11c-39c52797dc56) |
 
@@ -16,23 +16,23 @@ The following options can be changed directly from the main menu under `UI Setti
 
 | Setting | Description | Options |
 | -- | -- | -- |
-| Distribution | Used to define which folder to look in for Theme Customization files. | `Batocera`, `RetroBat` | 
+| Distribution | Used to define which folder to look in for Theme Customization files. | `Batocera`, `RetroBat` |
 | Aspect Ratio | Enables you to select the correct aspect ratio for your screen.  This will automatically set itself so you should not need to change it but if the theme layout looks odd or spacing looks incorrect you can use this setting to make sure the aspect ratio matches your screen. | `16:9`, `16:10`, `4:3`, `3:2`, `5:3`, `1:1` |
 | Color Scheme | Sets the color scheme that is used for the theme.  There is a set of prebuilt color schemes that you can select and an option to supply your custom color scheme (selected by choosing `custom`).  You can see details on customizations below under [Theme Customizations](#theme-customizations). | `Art Book Next`, `Art Book`, `Steam OS`, `SNES`, `Famicom`, `Black`, `Grayscale`, `Custom` |
 | Font Size | When this is set to custom it allows you to define custom font sizes for the gamelist.  You can see details on customizations below under [Theme Customizations](#theme-customizations). | `Default`, `Custom` |
-| System View Style | Defines the layout/design used for the System View | `Multi Artwork`, `Centered Artwork (Multiple Logos)`, `Centered Artwork (Single Logo)`, `No Artwork`, `Custom` | 
-| Gamelist View Style | Defines the layout/design used for the Gamelist View | `Metadata On`, `Metadata On (Immersive)`, `Metadata Off`, `Metadata Off (Immersive)` | 
+| System View Style | Defines the layout/design used for the System View | `Multi Artwork`, `Centered Artwork (Multiple Logos)`, `Centered Artwork (Single Logo)`, `No Artwork`, `Custom` |
+| Gamelist View Style | Defines the layout/design used for the Gamelist View | `Metadata On`, `Metadata On (Immersive)`, `Metadata Off`, `Metadata Off (Immersive)` |
 
 ## Theme Customizations
 
 Art Book Next allows customizations to artwork, colors and fonts without the need to edit the source XML.  This enables you to change the look of the theme and still retain any changes when your OS is updated.
 
-### Start Here 
+### Start Here
 - Make sure the `Distribution` setting is set to the correct value for your current OS (e.g. Batocera, JELOS or RetroBat)
 - This value determines the folder where you will add your customizations
     - Batocera = `userdata/theme-customizations/art-book-next/`
     - Retrobat = `C:\RetroBat\emulationstation\.emulationstation\theme-customizations\art-book-next\`
-- Create the folders that match your distribution and then move on to the options below... 
+- Create the folders that match your distribution and then move on to the options below...
 
 ### Background Art
 
@@ -48,7 +48,7 @@ The artwork used on the system view can be customized with your own images.  You
 - The theme will look them them up in that order.  If a given image is not found in your folder then the the images from the theme will be used as a fallback.  This allows you to customize only the images you want and still have images displayed for all systems.
 - `_default.jpg/png` can be used for creating a single image that is used for all systems OR a fallback for systems that you did not create a custom image for (if you don't want to use the fallback that already exists in the theme)
 - `${system.theme}.jpg/png` should be named for the system you are looking to override.  For example if you wanted to override the artwork for `snes` you would create an image called `snes.jpg` or `snes.png` in the backgrounds folder
-- once your images are in place you turn on custom images by changing the System View Style to either... 
+- once your images are in place you turn on custom images by changing the System View Style to either...
     - Centered Artwork (Custom)
     - Multi Artwork (Custom)
     - Fullscreen Artwork (Custom)
@@ -56,7 +56,7 @@ The artwork used on the system view can be customized with your own images.  You
 
 To create `centered` artwork that matches the mask used in the theme you can use the `system-art-mask` files I supply in the theme's resources directory [here](https://github.com/anthonycaccese/art-book-next-es/tree/main/resources/customizations).  I have tried to include a mask that should work in each major editing program.
 
-If you create a set of images that you would like to share with the community please let me know about it [here](https://retropie.org.uk/forum/topic/33010/theme-art-book-next) 
+If you create a set of images that you would like to share with the community please let me know about it [here](https://retropie.org.uk/forum/topic/33010/theme-art-book-next)
 
 ### Color Schemes
 
@@ -64,7 +64,7 @@ You can create your own custom color scheme to use for the theme
 
 - Download this template: https://github.com/anthonycaccese/art-book-next-es/blob/main/resources/customizations/colors.xml
 - Upload it in the path you created above and make sure its called `colors.xml`
-- Change any values in the template to the colors you prefer.  
+- Change any values in the template to the colors you prefer.
 - I tried to make the values as self explanatory as possible but if you have questions regarding which property does what please don't hesitate to ask.
 - After your colors are defined; in theme configuration change `Color Scheme` to `Custom`
 
@@ -87,7 +87,7 @@ You can modify the font size used to display gamelists
 
 - Download this template: https://github.com/anthonycaccese/art-book-next-es/blob/main/resources/customizations/fonts.xml
 - Upload it in the path you created above and make sure its called `fonts.xml`
-- Change any values in the above template to the sizes you like. 
+- Change any values in the above template to the sizes you like.
 - After your sizes are defined; in theme configuration change `Font Size` to `Custom`
 
 ## **Additional Notes**


### PR DESCRIPTION
Fix some typos in the README.md:
Customziations **->** Customizations
matche **->** match
licence **->** license

I also deleted trailing newlines with whitespaces because it is a widely used convention to improve code readability.
Removing trailing whitespace follows predominant coding styles and conventions across languages and tools.

[Markdown style guide](https://google.github.io/styleguide/docguide/style.html#trailing-whitespace)

> Don’t use trailing whitespace, use a trailing backslash.
> 
> The CommonMark spec decrees that two spaces at the end of a line should insert a <br /> tag. However, many directories have a trailing whitespace presubmit check in place, and many IDEs will clean it up anyway.
> 
> Best practice is to avoid the need for a <br /> altogether. Markdown creates paragraph tags for you simply with newlines: get used to that.

[PEP 8 style guide for Python considers it good practice](https://peps.python.org/pep-0008/#other-recommendations):

> Avoid trailing whitespace anywhere. Because it’s usually invisible, it can be confusing: e.g. a backslash followed by a space and a newline does not count as a line continuation marker. Some editors don’t preserve it and many projects (like CPython itself) have pre-commit hooks that reject it.

[The Ruby style guide also recommends it](https://rubystyle.guide/#no-trailing-whitespace):

> Avoid trailing whitespace.