### PR TITLE
Play stats

### DIFF
--- a/aspect-ratio-1-1.xml
+++ b/aspect-ratio-1-1.xml
@@ -109,7 +109,7 @@ based on 480x480
    View: Gamelist (Detailed - Metadata On)
    ///
    -->
-   <view name="detailed" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats">
       <!-- Video -->
       <video name="game-video" extra="true">
          <pos>0.75 0.25</pos><!-- 360 120 -->
@@ -140,7 +140,7 @@ based on 480x480
          <lineSpacing>1.2</lineSpacing>
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on|play-stats">
       <rating name="md_rating">
          <origin>1 0.5</origin>
          <pos>0.9479166666666667 0.614583333333333</pos><!-- 455 295 -->

--- a/aspect-ratio-1-1.xml
+++ b/aspect-ratio-1-1.xml
@@ -109,7 +109,7 @@ based on 480x480
    View: Gamelist (Detailed - Metadata On)
    ///
    -->
-   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <!-- Video -->
       <video name="game-video" extra="true">
          <pos>0.75 0.25</pos><!-- 360 120 -->
@@ -140,7 +140,7 @@ based on 480x480
          <lineSpacing>1.2</lineSpacing>
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <rating name="md_rating">
          <origin>1 0.5</origin>
          <pos>0.9479166666666667 0.614583333333333</pos><!-- 455 295 -->

--- a/aspect-ratio-16-10.xml
+++ b/aspect-ratio-16-10.xml
@@ -107,7 +107,7 @@ based on 768x480
    View: Gamelist (Detailed - Metadata On)
    ///
    -->
-   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <!-- Video -->
       <video ifHelpPrompts="true" name="game-video" extra="true">
          <pos>0.68757327080891 0.296875</pos><!-- 586.5 142.5 -->
@@ -169,7 +169,7 @@ based on 768x480
          <visible>true</visible>
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="true" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifHelpPrompts="true" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <image name="
          game-releasedate-icon,
          game-players-icon
@@ -192,7 +192,7 @@ based on 768x480
          <pos>0.846354166666667 0.802083333333333</pos><!-- 650 385 -->
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <image name="
          game-releasedate-icon,
          game-players-icon,

--- a/aspect-ratio-16-10.xml
+++ b/aspect-ratio-16-10.xml
@@ -107,7 +107,7 @@ based on 768x480
    View: Gamelist (Detailed - Metadata On)
    ///
    -->
-   <view name="detailed" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats">
       <!-- Video -->
       <video ifHelpPrompts="true" name="game-video" extra="true">
          <pos>0.68757327080891 0.296875</pos><!-- 586.5 142.5 -->
@@ -169,7 +169,7 @@ based on 768x480
          <visible>true</visible>
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="true" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifHelpPrompts="true" ifSubset="gamelist-view-metadata:on|play-stats">
       <image name="
          game-releasedate-icon,
          game-players-icon
@@ -192,7 +192,7 @@ based on 768x480
          <pos>0.846354166666667 0.802083333333333</pos><!-- 650 385 -->
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on|play-stats">
       <image name="
          game-releasedate-icon,
          game-players-icon,
@@ -220,7 +220,7 @@ based on 768x480
       <image name="game-gametime-icon">
          <pos>0.8203125 0.866666666666667</pos><!-- 630 416 -->
       </image>
-      <text name="md_gametime">
+      <text name="game-gametime-formatted">
          <pos>0.846354166666667 0.866666666666667</pos><!-- 650 416 -->
          <visible>true</visible>
       </text>

--- a/aspect-ratio-16-9.xml
+++ b/aspect-ratio-16-9.xml
@@ -107,7 +107,7 @@ based on 853x480
    View: Gamelist (Detailed - Metadata On)
    ///
    -->
-   <view name="detailed" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats">
       <!-- Video -->
       <video ifHelpPrompts="true" name="game-video" extra="true">
          <pos>0.68757327080891 0.296875</pos><!-- 586.5 142.5 -->
@@ -167,7 +167,7 @@ based on 853x480
          <visible>true</visible>
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="true" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifHelpPrompts="true" ifSubset="gamelist-view-metadata:on|play-stats">
       <rating name="md_rating">
          <pos>0.836459554513482 0.6796875</pos><!-- 713.5 326.25 -->
       </rating>
@@ -190,7 +190,7 @@ based on 853x480
          <pos>0.863423212192263 0.802083333333333</pos><!-- 736.5 385 -->
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on|play-stats">
       <rating name="md_rating">
          <pos>0.836459554513482 0.713541666666667</pos><!-- 713.5 342.5 -->
       </rating>
@@ -218,7 +218,7 @@ based on 853x480
       <image name="game-gametime-icon">
          <pos>0.836459554513482 0.866666666666667</pos><!-- 713.5 416 -->
       </image>
-      <text name="md_gametime">
+      <text name="game-gametime-formatted">
          <pos>0.863423212192263 0.866666666666667</pos><!-- 736.5 416 -->
          <visible>true</visible>
       </text>

--- a/aspect-ratio-16-9.xml
+++ b/aspect-ratio-16-9.xml
@@ -107,7 +107,7 @@ based on 853x480
    View: Gamelist (Detailed - Metadata On)
    ///
    -->
-   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <!-- Video -->
       <video ifHelpPrompts="true" name="game-video" extra="true">
          <pos>0.68757327080891 0.296875</pos><!-- 586.5 142.5 -->
@@ -167,7 +167,7 @@ based on 853x480
          <visible>true</visible>
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="true" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifHelpPrompts="true" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <rating name="md_rating">
          <pos>0.836459554513482 0.6796875</pos><!-- 713.5 326.25 -->
       </rating>
@@ -190,7 +190,7 @@ based on 853x480
          <pos>0.863423212192263 0.802083333333333</pos><!-- 736.5 385 -->
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <rating name="md_rating">
          <pos>0.836459554513482 0.713541666666667</pos><!-- 713.5 342.5 -->
       </rating>

--- a/aspect-ratio-3-2.xml
+++ b/aspect-ratio-3-2.xml
@@ -109,7 +109,7 @@ based on 720x480
    View: Gamelist (Detailed - Metadata On)
    ///
    -->
-   <view name="detailed" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats">
       <!-- Video -->
       <video ifHelpPrompts="true" name="game-video" extra="true">
          <pos>0.6875 0.296875</pos><!-- 528 142.5 -->
@@ -170,7 +170,7 @@ based on 720x480
          <visible>true</visible>
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="true" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifHelpPrompts="true" ifSubset="gamelist-view-metadata:on|play-stats">
       <rating name="md_rating">
          <pos>0.8203125 0.6796875</pos><!-- 630 326.25 -->
       </rating>
@@ -193,7 +193,7 @@ based on 720x480
          <pos>0.846354166666667 0.802083333333333</pos><!-- 650 385 -->
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on|play-stats">
       <rating name="md_rating">
          <pos>0.8203125 0.713541666666667</pos><!-- 630 342.5 -->
       </rating>
@@ -221,7 +221,7 @@ based on 720x480
       <image name="game-gametime-icon">
          <pos>0.8203125 0.866666666666667</pos><!-- 630 416 -->
       </image>
-      <text name="md_gametime">
+      <text name="game-gametime-formatted">
          <pos>0.846354166666667 0.866666666666667</pos><!-- 650 416 -->
          <visible>true</visible>
       </text>

--- a/aspect-ratio-3-2.xml
+++ b/aspect-ratio-3-2.xml
@@ -109,7 +109,7 @@ based on 720x480
    View: Gamelist (Detailed - Metadata On)
    ///
    -->
-   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <!-- Video -->
       <video ifHelpPrompts="true" name="game-video" extra="true">
          <pos>0.6875 0.296875</pos><!-- 528 142.5 -->
@@ -170,7 +170,7 @@ based on 720x480
          <visible>true</visible>
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="true" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifHelpPrompts="true" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <rating name="md_rating">
          <pos>0.8203125 0.6796875</pos><!-- 630 326.25 -->
       </rating>
@@ -193,7 +193,7 @@ based on 720x480
          <pos>0.846354166666667 0.802083333333333</pos><!-- 650 385 -->
       </text>
    </view>
-   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <rating name="md_rating">
          <pos>0.8203125 0.713541666666667</pos><!-- 630 342.5 -->
       </rating>

--- a/aspect-ratio-4-3.xml
+++ b/aspect-ratio-4-3.xml
@@ -111,7 +111,7 @@ based on 640x480
    View: Gamelist (Detailed - Metadata On)
    ///
    -->
-   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <!-- Video -->
       <video name="game-video" extra="true">
          <pos>0.75 0.25</pos><!-- 480 120 -->
@@ -169,17 +169,34 @@ based on 640x480
          <visible>true</visible>
       </rating>
    </view>
-   <variables ifSubset="gamelist-view-metadata:play-stats">
+   <variables ifSubset="gamelist-view-metadata:play-stats|mixed">
       <gamelistMetadataFontSize ifSubset="font-size:small">0.033333333333333</gamelistMetadataFontSize><!-- 16 -->
-      <gamelistMetadataFontSize ifSubset="font-size:default|large">0.0375</gamelistMetadataFontSize><!-- 18 -->
+      <gamelistMetadataFontSize ifSubset="font-size:default|large,gamelist-view-metadata:play-stats">0.0375</gamelistMetadataFontSize><!-- 18 -->
+      <gamelistMetadataFontSize ifSubset="font-size:default|large,gamelist-view-metadata:mixed">0.033333333333333</gamelistMetadataFontSize><!-- 16 -->
    </variables>
-   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:play-stats">
+   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:play-stats|mixed">
       <stackpanel name="gamedata" extra="true">
          <separator>0.015625</separator><!-- 10 -->
          <pos>0.55078125 0.6</pos><!-- 352.5 288 -->
          <size>0.3984375 0.0416666666666667</size>
          <orientation>horizontal</orientation>
          <zIndex>99</zIndex>
+         <image name="gamedata-releasedate-icon" ifSubset="gamelist-view-metadata:mixed">
+            <maxSize>1 1</maxSize>
+            <path>./_inc/images/metadata-icon-releasedate.svg</path>
+            <color>${gamelistListMetadataIconColor}</color>
+         </image>
+         <text name="gamedata-releasedate" ifSubset="gamelist-view-metadata:mixed">
+            <fontPath>${fontBold}</fontPath>
+            <fontSize>${gamelistMetadataFontSize}</fontSize>
+            <text>{game:releaseyear}</text>
+            <color>${gamelistListMetadataColor}</color>
+         </text>
+         <image ifSubset="gamelist-view-metadata:mixed">
+            <maxSize>0.028125 1</maxSize><!-- 18 20 -->
+            <path>${spacerImage}</path>
+            <color>00000000</color>
+         </image>
          <image name="gamedata-gametime-icon">
             <maxSize>1 1</maxSize>
             <path>./_inc/images/metadata-icon-gametime.svg</path>
@@ -191,18 +208,18 @@ based on 640x480
             <text>{game:gametime} > 0 ? expandseconds({game:gametime}) : "Never Played"</text>
             <color>${gamelistListMetadataColor}</color>
          </text>
-         <image>
+         <image ifSubset="gamelist-view-metadata:play-stats">
             <maxSize>0.028125 1</maxSize><!-- 18 20 -->
             <path>${spacerImage}</path>
             <color>00000000</color>
          </image>
-         <image name="gamedata-playcount-icon">
+         <image name="gamedata-playcount-icon" ifSubset="gamelist-view-metadata:play-stats">
             <maxSize>1 1</maxSize>
             <path>./_inc/images/metadata-icon-playcount.svg</path>
             <color>${gamelistListMetadataIconColor}</color>
             <visible>{game:gametime} > 0</visible>
          </image>
-         <text name="gamedata-playcount">
+         <text name="gamedata-playcount" ifSubset="gamelist-view-metadata:play-stats">
             <fontPath>${fontBold}</fontPath>
             <fontSize>${gamelistMetadataFontSize}</fontSize>
             <text>{game:playcount}</text>

--- a/aspect-ratio-4-3.xml
+++ b/aspect-ratio-4-3.xml
@@ -170,48 +170,16 @@ based on 640x480
       </rating>
    </view>
    <variables ifSubset="gamelist-view-metadata:play-stats">
-      <gamelistMetadataFontSize ifSubset="font-size:small|default">0.03125</gamelistMetadataFontSize><!-- 15 -->
-      <gamelistMetadataFontSize ifSubset="font-size:large">0.039583333333333</gamelistMetadataFontSize><!-- 19 -->
+      <gamelistMetadataFontSize ifSubset="font-size:small">0.033333333333333</gamelistMetadataFontSize><!-- 16 -->
+      <gamelistMetadataFontSize ifSubset="font-size:default|large">0.0375</gamelistMetadataFontSize><!-- 18 -->
    </variables>
    <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:play-stats">
       <stackpanel name="gamedata" extra="true">
-         <separator>0.0125</separator><!-- 8 -->
+         <separator>0.015625</separator><!-- 10 -->
          <pos>0.55078125 0.6</pos><!-- 352.5 288 -->
          <size>0.3984375 0.0416666666666667</size>
          <orientation>horizontal</orientation>
          <zIndex>99</zIndex>
-         <image name="gamedata-releasedate-icon">
-            <maxSize>1 1</maxSize>
-            <path>./_inc/images/metadata-icon-releasedate.svg</path>
-            <color>${gamelistListMetadataIconColor}</color>
-         </image>
-         <text name="gamedata-releasedate">
-            <fontPath>${fontBold}</fontPath>
-            <fontSize>${gamelistMetadataFontSize}</fontSize>
-            <text>{game:releaseyear}</text>
-            <color>${gamelistListMetadataColor}</color>
-         </text>
-         <image ifSubset="font-size:small|default">
-            <maxSize>0.021875 1</maxSize>
-            <path>${spacerImage}</path>
-            <color>00000000</color>
-         </image>
-         <image name="gamedata-playcount-icon" ifSubset="font-size:small|default">
-            <maxSize>1 1</maxSize>
-            <path>./_inc/images/metadata-icon-playcount.svg</path>
-            <color>${gamelistListMetadataIconColor}</color>
-         </image>
-         <text name="gamedata-playcount" ifSubset="font-size:small|default">
-            <fontPath>${fontBold}</fontPath>
-            <fontSize>${gamelistMetadataFontSize}</fontSize>
-            <text>{game:playcount}</text>
-            <color>${gamelistListMetadataColor}</color>
-         </text>
-         <image>
-            <maxSize>0.021875 1</maxSize>
-            <path>${spacerImage}</path>
-            <color>00000000</color>
-         </image>
          <image name="gamedata-gametime-icon">
             <maxSize>1 1</maxSize>
             <path>./_inc/images/metadata-icon-gametime.svg</path>
@@ -220,8 +188,26 @@ based on 640x480
          <text name="gamedata-gametime">
             <fontPath>${fontBold}</fontPath>
             <fontSize>${gamelistMetadataFontSize}</fontSize>
-            <text>{game:gametime} > 0 ? formatseconds({game:gametime}) : "Never"</text>
+            <text>{game:gametime} > 0 ? expandseconds({game:gametime}) : "Never Played"</text>
             <color>${gamelistListMetadataColor}</color>
+         </text>
+         <image>
+            <maxSize>0.028125 1</maxSize><!-- 18 20 -->
+            <path>${spacerImage}</path>
+            <color>00000000</color>
+         </image>
+         <image name="gamedata-playcount-icon">
+            <maxSize>1 1</maxSize>
+            <path>./_inc/images/metadata-icon-playcount.svg</path>
+            <color>${gamelistListMetadataIconColor}</color>
+            <visible>{game:gametime} > 0</visible>
+         </image>
+         <text name="gamedata-playcount">
+            <fontPath>${fontBold}</fontPath>
+            <fontSize>${gamelistMetadataFontSize}</fontSize>
+            <text>{game:playcount}</text>
+            <color>${gamelistListMetadataColor}</color>
+            <visible>{game:gametime} > 0</visible>
          </text>
       </stackpanel>
    </view>

--- a/aspect-ratio-4-3.xml
+++ b/aspect-ratio-4-3.xml
@@ -64,6 +64,8 @@ based on 640x480
          <pos>0.0546875 0.25</pos><!-- 35 120 -->
          <lines ifSubset="font-size:default" ifHelpPrompts="true">7</lines>
          <lines ifSubset="font-size:default" ifHelpPrompts="false">9</lines>
+         <lines ifSubset="font-size:large" ifHelpPrompts="true">7</lines>
+         <lines ifSubset="font-size:large" ifHelpPrompts="false">7</lines>
       </textlist>
    </view>
 
@@ -109,7 +111,7 @@ based on 640x480
    View: Gamelist (Detailed - Metadata On)
    ///
    -->
-   <view name="detailed" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats">
       <!-- Video -->
       <video name="game-video" extra="true">
          <pos>0.75 0.25</pos><!-- 480 120 -->
@@ -133,20 +135,20 @@ based on 640x480
       </image>
       <text name="game-description" extra="true">
          <x>0.55078125</x><!-- 352.5 -->
-         <y ifHelpPrompts="true">0.579166666666667</y><!-- 278 -->
-         <y ifHelpPrompts="false">0.69375</y><!-- 333 -->
+         <y ifHelpPrompts="true">0.58125</y><!-- 279 -->
+         <y ifHelpPrompts="false">0.691666666666667</y><!-- 332 -->
          <w>0.3984375</w><!-- 255 -->
          <h>0.25</h><!-- 120 -->
-         <lineSpacing>1.2</lineSpacing>
+         <lineSpacing ifSubset="font-size:small">1.46</lineSpacing>
+         <lineSpacing ifSubset="font-size:default|large">1.21</lineSpacing>
       </text>
    </view>
+   <variables ifSubset="gamelist-view-metadata:on">
+      <gamelistMetadataFontSize ifSubset="font-size:small">0.03125</gamelistMetadataFontSize><!-- 15 -->
+      <gamelistMetadataFontSize ifSubset="font-size:default">0.035416666666667</gamelistMetadataFontSize><!-- 17 -->
+      <gamelistMetadataFontSize ifSubset="font-size:large">0.039583333333333</gamelistMetadataFontSize><!-- 19 -->
+   </variables>
    <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:on">
-      <rating name="md_rating">
-         <origin>1 0.5</origin>
-         <pos>0.953125 0.614583333333333</pos><!-- 610 295 -->
-         <size>0 0.041666666666667</size><!-- - 20 -->
-         <visible>true</visible>
-      </rating>
       <image name="game-releasedate-icon">
          <pos>0.55078125 0.616666666666667</pos><!-- 352.5 296 -->
          <maxSize>0.03125 0.0416666666666667</maxSize><!-- 20 20 -->
@@ -154,10 +156,74 @@ based on 640x480
       </image>
       <datetime name="md_releasedate">
          <pos>0.59375 0.616666666666667</pos><!-- 380 296 -->
-         <format ifSubset="font-size:small|default">%Y-%m-%d</format>
-         <format ifSubset="font-size:large">%Y-%m</format>
+         <format ifSubset="font-size:small">%Y-%m-%d</format>
+         <format ifSubset="font-size:default|large">%Y-%m</format>
          <visible>true</visible>
+         <fontSize>${gamelistMetadataFontSize}</fontSize>
       </datetime>
+      <rating name="md_rating">
+         <origin>1 0.5</origin>
+         <pos>0.953125 0.614583333333333</pos><!-- 610 295 -->
+         <size ifSubset="font-size:small">0 0.0375</size><!-- - 18 --> 
+         <size ifSubset="font-size:default|large">0 0.045833333333333</size><!-- - 20 --> 
+         <visible>true</visible>
+      </rating>
+   </view>
+   <variables ifSubset="gamelist-view-metadata:play-stats">
+      <gamelistMetadataFontSize ifSubset="font-size:small|default">0.03125</gamelistMetadataFontSize><!-- 15 -->
+      <gamelistMetadataFontSize ifSubset="font-size:large">0.039583333333333</gamelistMetadataFontSize><!-- 19 -->
+   </variables>
+   <view name="detailed" ifHelpPrompts="false" ifSubset="gamelist-view-metadata:play-stats">
+      <stackpanel name="gamedata" extra="true">
+         <separator>0.0125</separator><!-- 8 -->
+         <pos>0.55078125 0.6</pos><!-- 352.5 288 -->
+         <size>0.3984375 0.0416666666666667</size>
+         <orientation>horizontal</orientation>
+         <zIndex>99</zIndex>
+         <image name="gamedata-releasedate-icon">
+            <maxSize>1 1</maxSize>
+            <path>./_inc/images/metadata-icon-releasedate.svg</path>
+            <color>${gamelistListMetadataIconColor}</color>
+         </image>
+         <text name="gamedata-releasedate">
+            <fontPath>${fontBold}</fontPath>
+            <fontSize>${gamelistMetadataFontSize}</fontSize>
+            <text>{game:releaseyear}</text>
+            <color>${gamelistListMetadataColor}</color>
+         </text>
+         <image ifSubset="font-size:small|default">
+            <maxSize>0.021875 1</maxSize>
+            <path>${spacerImage}</path>
+            <color>00000000</color>
+         </image>
+         <image name="gamedata-playcount-icon" ifSubset="font-size:small|default">
+            <maxSize>1 1</maxSize>
+            <path>./_inc/images/metadata-icon-playcount.svg</path>
+            <color>${gamelistListMetadataIconColor}</color>
+         </image>
+         <text name="gamedata-playcount" ifSubset="font-size:small|default">
+            <fontPath>${fontBold}</fontPath>
+            <fontSize>${gamelistMetadataFontSize}</fontSize>
+            <text>{game:playcount}</text>
+            <color>${gamelistListMetadataColor}</color>
+         </text>
+         <image>
+            <maxSize>0.021875 1</maxSize>
+            <path>${spacerImage}</path>
+            <color>00000000</color>
+         </image>
+         <image name="gamedata-gametime-icon">
+            <maxSize>1 1</maxSize>
+            <path>./_inc/images/metadata-icon-gametime.svg</path>
+            <color>${gamelistListMetadataIconColor}</color>
+         </image>
+         <text name="gamedata-gametime">
+            <fontPath>${fontBold}</fontPath>
+            <fontSize>${gamelistMetadataFontSize}</fontSize>
+            <text>{game:gametime} > 0 ? formatseconds({game:gametime}) : "Never"</text>
+            <color>${gamelistListMetadataColor}</color>
+         </text>
+      </stackpanel>
    </view>
 
    <!--

--- a/theme.xml
+++ b/theme.xml
@@ -93,7 +93,8 @@ https://github.com/anthonycaccese/art-book-next-es
    -->
    <subset name="gamelist-view-metadata" displayName="Game Metadata">
       <include name="on" displayName="Default" />
-      <include ifSubset="aspect-ratio:4-3|4-3-auto" name="play-stats" displayName="Play Stats" />
+      <include ifSubset="aspect-ratio:4-3|4-3-auto" name="play-stats" displayName="Play Time &amp; Play Count" />
+      <include ifSubset="aspect-ratio:4-3|4-3-auto" name="mixed" displayName="Release Date &amp; Play Time" />
       <include name="off" displayName="Off" />
    </subset>
 
@@ -441,7 +442,7 @@ https://github.com/anthonycaccese/art-book-next-es
          <zIndex>3</zIndex>
       </image>
       <image ifSubset="gamelist-view-artwork:image-cropped" name="game-logo" extra="true">
-         <origin ifSubset="gamelist-view-metadata:on|play-stats">0 1</origin>
+         <origin ifSubset="gamelist-view-metadata:on|play-stats|mixed">0 1</origin>
          <origin ifSubset="gamelist-view-metadata:off">0.5 0.5</origin>
          <path>{game:marquee}</path>
          <autoFade>false</autoFade>
@@ -471,7 +472,7 @@ https://github.com/anthonycaccese/art-book-next-es
       <gamelistMetadataFontSize ifSubset="font-size:default">0.033333333333333</gamelistMetadataFontSize><!-- 16 -->
       <gamelistMetadataFontSize ifSubset="font-size:large">0.039583333333333</gamelistMetadataFontSize><!-- 19 -->
    </variables>
-   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats">
+   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats|mixed">
       <text name="game-description" extra="true">
          <origin>0 0</origin>
          <y ifHelpPrompts="true">0.6479166666666667</y><!-- 311 -->

--- a/theme.xml
+++ b/theme.xml
@@ -92,7 +92,8 @@ https://github.com/anthonycaccese/art-book-next-es
    ///
    -->
    <subset name="gamelist-view-metadata" displayName="Game Metadata">
-      <include name="on" displayName="On" />
+      <include name="on" displayName="Default" />
+      <include ifSubset="aspect-ratio:4-3|4-3-auto" name="play-stats" displayName="Play Stats" />
       <include name="off" displayName="Off" />
    </subset>
 
@@ -372,14 +373,14 @@ https://github.com/anthonycaccese/art-book-next-es
          <h ifHelpPrompts="false">0.7</h><!-- 336 -->
          <!-- small font -->
          <fontSize ifSubset="font-size:small">0.033333333333333</fontSize><!-- 16 -->
-         <lines ifSubset="font-size:small" ifHelpPrompts="true">11</lines>
-         <lines ifSubset="font-size:small" ifHelpPrompts="false">13</lines>
+         <lines ifSubset="font-size:small" ifHelpPrompts="true">9</lines>
+         <lines ifSubset="font-size:small" ifHelpPrompts="false">11</lines>
          <!-- default font -->
          <fontSize ifSubset="font-size:default">0.041666666666667</fontSize><!-- 20 -->
-         <lines ifSubset="font-size:default" ifHelpPrompts="true">9</lines>
-         <lines ifSubset="font-size:default" ifHelpPrompts="false">11</lines>
+         <lines ifSubset="font-size:default" ifHelpPrompts="true">7</lines>
+         <lines ifSubset="font-size:default" ifHelpPrompts="false">9</lines>
          <!-- large font -->
-         <fontSize ifSubset="font-size:large">0.05</fontSize><!-- 24 -->
+         <fontSize ifSubset="font-size:large">0.045833333333333</fontSize><!-- 22 -->
          <lines ifSubset="font-size:large" ifHelpPrompts="true">7</lines>
          <lines ifSubset="font-size:large" ifHelpPrompts="false">9</lines>
          <fontPath>${fontBold}</fontPath>
@@ -440,7 +441,7 @@ https://github.com/anthonycaccese/art-book-next-es
          <zIndex>3</zIndex>
       </image>
       <image ifSubset="gamelist-view-artwork:image-cropped" name="game-logo" extra="true">
-         <origin ifSubset="gamelist-view-metadata:on">0 1</origin>
+         <origin ifSubset="gamelist-view-metadata:on|play-stats">0 1</origin>
          <origin ifSubset="gamelist-view-metadata:off">0.5 0.5</origin>
          <path>{game:marquee}</path>
          <autoFade>false</autoFade>
@@ -467,10 +468,10 @@ https://github.com/anthonycaccese/art-book-next-es
    -->
    <variables>
       <gamelistMetadataFontSize ifSubset="font-size:small">0.029166666666667</gamelistMetadataFontSize><!-- 14 -->
-      <gamelistMetadataFontSize ifSubset="font-size:large">0.039583333333333</gamelistMetadataFontSize><!-- 19 -->
       <gamelistMetadataFontSize ifSubset="font-size:default">0.033333333333333</gamelistMetadataFontSize><!-- 16 -->
+      <gamelistMetadataFontSize ifSubset="font-size:large">0.039583333333333</gamelistMetadataFontSize><!-- 19 -->
    </variables>
-   <view name="detailed" ifSubset="gamelist-view-metadata:on">
+   <view name="detailed" ifSubset="gamelist-view-metadata:on|play-stats">
       <text name="game-description" extra="true">
          <origin>0 0</origin>
          <y ifHelpPrompts="true">0.6479166666666667</y><!-- 311 -->
@@ -527,14 +528,24 @@ https://github.com/anthonycaccese/art-book-next-es
          <path>./_inc/images/metadata-icon-gametime.svg</path>
       </image>
       <text name="
-         md_gametime
          md_playcount
-         md_players">
+         md_players
+         md_gametime
+         ">
          <origin>0 0.5</origin>
          <fontSize>${gamelistMetadataFontSize}</fontSize>
          <fontPath>${fontBold}</fontPath>
          <lineSpacing>1</lineSpacing>
          <color>${gamelistListMetadataColor}</color>
+      </text>
+      <text name="game-gametime-formatted" extra="true">
+         <visible>false</visible>
+         <origin>0 0.5</origin>
+         <fontSize>${gamelistMetadataFontSize}</fontSize>
+         <fontPath>${fontBold}</fontPath>
+         <lineSpacing>1</lineSpacing>
+         <color>${gamelistListMetadataColor}</color>
+         <text>{game:gametime} > 0 ? formatseconds({game:gametime}) : "Never"</text>
       </text>
       <!-- End: Definitions -->
    </view>


### PR DESCRIPTION
Adds 2 new metadata options for 4:3 aspect ratio
1. Play Time &amp; Play Count
2. Release Date &amp; Play Time

The options can be found under "Game Metadata" when using 4:3 aspect ratio.

Inspired by the work done by @chrizzo-hb and updated to use more current theme logic provided by the latest version of ES